### PR TITLE
[FIX] Operators precedence error on final evaluation

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
           </section>
     </main>
   </body>
+  <script src="./js/evalutor.js"></script>
   <script src="./js/main.js"></script>
   <script src="./js/togglebtn.js"></script>
 </html>

--- a/js/evalutor.js
+++ b/js/evalutor.js
@@ -1,0 +1,86 @@
+class Postfix {
+	/**
+	*	Postifix evalutor, accept an infix expression and convert into 
+	*	postfix expression for a better evalution.
+	*
+	*	Read more about infix and postfix expression
+	*   - https://www.geeksforgeeks.org/stack-set-2-infix-to-postfix/
+	*/
+
+	ops = {"*": 2, "%": 2, "/": 2 , "-": 1, "+": 1}
+
+	/**
+	 * Check a given character is one of allowed operators
+	 * @param  {String} char character to be checked.
+	 * @return {Boolean}     true if a character is operator false otherwise.
+	 */
+	isOperator(char) {
+
+		return char in this.ops
+	}
+
+	/**
+	 * Compare a gived operators precedence
+	 * @param  {String} op1  first operator
+	 * @param  {String} op2  second operator 
+	 * @return {Boolean}     true if a first operator precedence is greater that or
+	 * 						 equal with second operator is operator false otherwise.
+	 */
+	isHiger(op1, op2) {return this.ops[op1] >= this.ops[op2]}
+
+	/**
+	 * Convert a given infix expression into a postfix expression
+	 * @param  {String} infix_expression  infix expression that needed to be converted
+	 * @return {String}     			  postfix expression
+	 */
+	toExpression(infix_expression) {
+		Array.prototype.empty = function() { return this.length == 0 }
+		Array.prototype.top = function() { return this[this.length - 1] }
+
+		var postfix_exp = []
+		var operators = []
+
+		for(var char of infix_expression.split(" ")) {
+			if (this.isOperator(char)){
+				if (operators.empty()){
+					operators.push(char)
+				}
+				else {
+					while (!operators.empty() && this.isHiger(operators.top(), char)){
+						postfix_exp.push(operators.pop())
+					}
+					operators.push(char)
+				}
+			}
+			else {
+				postfix_exp.push(char)
+			}
+		}
+		while (!operators.empty()) {
+			postfix_exp.push(operators.pop())
+		}
+		return postfix_exp.join(" ");
+	}
+}
+
+/**
+ * Evaluate a given infix expression by converting into postfix
+ * @param  {String} infix_expression  infix expression to be evaluated
+ * @return {Integer}     			  evaluation result
+ */
+function evaluate(infix_expression) {
+	var postfix= new Postfix()
+	var values = []
+
+	postfix_expression = postfix.toExpression(infix_expression).split(" ")
+	for (var char of postfix_expression) {
+		if (postfix.isOperator(char)) {
+			var y = values.pop()
+			var x = values.pop()
+			values.push(eval(`${x} ${char} ${y}`))
+		} else {
+			values.push(char)
+		}
+	}
+	return values[0];
+}

--- a/js/main.js
+++ b/js/main.js
@@ -48,25 +48,15 @@ function clearVar(name = "") {
 }
 
 function mathOperation() {
-  if (lastOperation === "x") {
-    result = parseFloat(result) * parseFloat(dis2Num);
-  } else if (lastOperation === "+") {
-    result = parseFloat(result) + parseFloat(dis2Num);
-  } else if (lastOperation === "-") {
-    result = parseFloat(result) - parseFloat(dis2Num);
-  } else if (lastOperation === "/") {
-    result = parseFloat(result) / parseFloat(dis2Num);
-  } else if (lastOperation === "%") {
-    result = parseFloat(result) % parseFloat(dis2Num);
-  }
+  result  =`${result} ${lastOperation} ${dis2Num}`
 }
-// operation();
 
 equalEl.addEventListener("click", () => {
   if (!dis2Num || !dis1Num) return;
   haveDot = false;
   mathOperation();
   clearVar();
+  result = evaluate(result.replaceAll("x", "*"))
   display2El.innerText = result;
   tempResultEl.innerText = "";
   dis2Num = result;
@@ -94,10 +84,10 @@ del.addEventListener(`click`, ()=>{
 })
 
 
-
-
-
 window.addEventListener("keydown", (e) => {
+  if (e.key === '/' || e.key === 'Backspace'){
+    e.preventDefault();
+  }
   if (
     e.key === "0" ||
     e.key === "1" ||


### PR DESCRIPTION
## Description

Fix operator precedence error on final evaluation by first converting a given expression into postfix expression and evaluating as it is.

Fixes #23 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings